### PR TITLE
Set dropdown items as active

### DIFF
--- a/escape.html
+++ b/escape.html
@@ -45,7 +45,7 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
+            <a class="dropdown-item active" href="escape.html">Escape Rooms</a>
             <a class="dropdown-item" href="hitman2.html">Hitman 2 (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>

--- a/golf.html
+++ b/golf.html
@@ -44,6 +44,7 @@
             <a class="dropdown-item" href="nes2.html">NES Classics (Week 2)</a>
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
+            <a class="dropdown-item active" href="golf.html">Golf With Your Friends</a>
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
             <a class="dropdown-item" href="hitman2.html">Hitman 2 (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>

--- a/guts.html
+++ b/guts.html
@@ -40,8 +40,10 @@
                         Guts and Glory
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                        <a class="dropdown-item" href="index.html">COD: Warzone</a>
                         <a class="dropdown-item" href="nes2.html">NES Classics (Week 2)</a>
                         <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
+                        <a class="dropdown-item active" href="guts.html">Guts and Glory</a>
                         <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
                         <a class="dropdown-item" href="escape.html">Escape Rooms</a>
                         <a class="dropdown-item" href="hitman2.html">Hitman 2 (Week 2)</a>

--- a/hitman.html
+++ b/hitman.html
@@ -51,6 +51,7 @@
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>
+            <a class="dropdown-item active" href="hitman.html">Hitman 2 (Week 1)</a>
             <a class="dropdown-item" href="tarkov.html">Escape from Tarkov</a>
             <a class="dropdown-item" href="spelunky.html">Spelunky</a>
 

--- a/hitman2.html
+++ b/hitman2.html
@@ -46,6 +46,7 @@
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
+            <a class="dropdown-item active" href="hitman2.html">Hitman 2 (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             COD: Warzone
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item active" href="index.html">COD: Warzone</a>
             <a class="dropdown-item" href="nes2.html">NES Classics (Week 2)</a>
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>

--- a/index.html
+++ b/index.html
@@ -37,10 +37,9 @@
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
-            NES Classics (Week 2)
+            COD: Warzone
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="index.html">COD: Warzone</a>
             <a class="dropdown-item" href="nes2.html">NES Classics (Week 2)</a>
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>

--- a/nes.html
+++ b/nes.html
@@ -50,6 +50,7 @@
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
+            <a class="dropdown-item active" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>
             <a class="dropdown-item" href="hitman.html">Hitman 2 (Week 1)</a>

--- a/nes2.html
+++ b/nes2.html
@@ -41,6 +41,7 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-item" href="index.html">COD: Warzone</a>
+                        <a class="dropdown-item active" href="nes2.html">NES Classics (Week 2)</a>
                         <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
                         <a class="dropdown-item" href="guts.html">Guts and Glory</a>
                         <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>

--- a/sega.html
+++ b/sega.html
@@ -46,12 +46,11 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
-
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
+            <a class="dropdown-item active" href="sega.html">SEGA Classics</a>
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>
             <a class="dropdown-item" href="hitman.html">Hitman 2 (Week 1)</a>
             <a class="dropdown-item" href="tarkov.html">Escape from Tarkov</a>

--- a/smm2.html
+++ b/smm2.html
@@ -42,6 +42,7 @@
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <a class="dropdown-item" href="index.html">COD: Warzone</a>
             <a class="dropdown-item" href="nes2.html">NES Classics (Week 2)</a>
+            <a class="dropdown-item active" href="nes2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>

--- a/snes.html
+++ b/snes.html
@@ -47,10 +47,9 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
-
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
+            <a class="dropdown-item active" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>

--- a/spelunky.html
+++ b/spelunky.html
@@ -45,9 +45,7 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
-
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
@@ -55,6 +53,7 @@
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>
             <a class="dropdown-item" href="hitman.html">Hitman 2 (Week 1)</a>
             <a class="dropdown-item" href="tarkov.html">Escape from Tarkov</a>
+            <a class="dropdown-item active" href="spelunky.html">Spelunky</a>
 
           </div>
         </li>

--- a/spire.html
+++ b/spire.html
@@ -46,13 +46,12 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
-
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>
+            <a class="dropdown-item active" href="spire.html">Slay the Spire</a>
             <a class="dropdown-item" href="hitman.html">Hitman 2 (Week 1)</a>
             <a class="dropdown-item" href="tarkov.html">Escape from Tarkov</a>
             <a class="dropdown-item" href="spelunky.html">Spelunky</a>

--- a/tarkov.html
+++ b/tarkov.html
@@ -46,15 +46,14 @@
             <a class="dropdown-item" href="smm2.html">Super Mario Maker 2</a>
             <a class="dropdown-item" href="guts.html">Guts and Glory</a>
             <a class="dropdown-item" href="golf.html">Golf With Your Friends</a>
-
             <a class="dropdown-item" href="escape.html">Escape Rooms</a>
-
             <a class="dropdown-item" href="hitman2.html">Hitman (Week 2)</a>
             <a class="dropdown-item" href="snes.html">SNES Classics</a>
             <a class="dropdown-item" href="nes.html">NES Classics (Week 1)</a>
             <a class="dropdown-item" href="sega.html">SEGA Classics</a>
             <a class="dropdown-item" href="spire.html">Slay the Spire</a>
             <a class="dropdown-item" href="hitman.html">Hitman 2 (Week 1)</a>
+            <a class="dropdown-item active" href="tarkov.html">Escape from Tarkov</a>
             <a class="dropdown-item" href="spelunky.html">Spelunky</a>
 
           </div>


### PR DESCRIPTION
This is more of a _suggestion_ than anything else.

In my opinion it's just more readable and semantic to not remove items from the dropdown nav and just keep them there as active.

For example I was confused when moving between some of the older items and I had to go back to another one to check which one went next.